### PR TITLE
Make python code more pythonic

### DIFF
--- a/arrays_lists/example.py
+++ b/arrays_lists/example.py
@@ -19,10 +19,10 @@ length = len(array)
 first_item = array[0]
 # "B"
 
-last_item = array[len(array) - 1]
+last_item = array[-1]
 # "H"
 
-nth_item = array[3];
+nth_item = array[3]
 # "E"
 
 position = array.index("F")

--- a/arrays_lists_iteration/example.py
+++ b/arrays_lists_iteration/example.py
@@ -7,7 +7,7 @@ list = [
 ]
 
 for i, el in enumerate(list):
-  print(str(i) + " " + el)
+  print(i, el)
 
 for item in list:
   print(item)

--- a/arrays_lists_iteration/example.py
+++ b/arrays_lists_iteration/example.py
@@ -6,8 +6,8 @@ list = [
     "Mostly Harmless"
 ]
 
-for i in range(len(list)):
-  print(str(i) + " " + list[i])
+for i, el in enumerate(list):
+  print(str(i) + " " + el)
 
 for item in list:
   print(item)

--- a/hash_maps_iteration/example.py
+++ b/hash_maps_iteration/example.py
@@ -7,7 +7,7 @@ hash_map = {
 }
 
 for key in hash_map:
-  print(key + " " + str(hash_map[key]))
+  print(key, hash_map[key])
 
 for key, value in hash_map.items():
-  print(key + " " + str(value))
+  print(key, value)

--- a/ifs/example.py
+++ b/ifs/example.py
@@ -2,41 +2,41 @@ boolean_value = True;
 
 if boolean_value:
   # if boolean_value is true
-  print
+  pass
 else:
   # if false
-  print
+  pass
 
 int_value = 0;
 
 if int_value >= 1:
   # if int_value is greater than or equal to 1
-  print
+  pass
 elif int_value < 0:
   # if int_value is less than 0
-  print
+  pass
 else:
   # if none of the options
-  print
+  pass
 
 string_value = "tea";
 
 if string_value == "tea":
   # if string_value is "tea"
-  print
+  pass
 elif string_value == "almost, but not quite, entirely unlike tea":
   # if string_value is "almost, but not quite, entirely unlike tea"
-  print
+  pass
 else:
   # if none of the options
-  print
+  pass
 
 if not boolean_value and string_value == "tea":
   # if boolean_value is false AND string_value is "tea"
-  print
+  pass
 elif boolean_value or int_value == 0:
   # if boolean_value is true OR int_value is equal to 0
-  print
+  pass
 else:
   # if none of the options
-  print
+  pass

--- a/interpolation/example.py
+++ b/interpolation/example.py
@@ -1,5 +1,5 @@
 author = "Douglas Adams"
 count = 7
 
-sentence = "%(author)s published %(count)s novels." % locals()
+sentence = "{author} published {count} novels.".format(**locals())
 # Douglas Adams published 7 novels.


### PR DESCRIPTION
The only controversial change here I think is the interpolation, arguably it should be 

``` python
"{} published {} novels.".format(author, count)
```

or

``` python
"{author} published {count} novels.".format(author=author, count=count)
```

but I didn't want to stray too far from what you'd already written.

It's also probably worth making it clear on the site that you use Python 3 syntax.
