### PR TITLE
To run C++ test check if g++ is installed.

### DIFF
--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -280,7 +280,7 @@ else
     echo "Install rust before running the Rust tests";
 fi
 
-if command_exists rustc; then
+if command_exists g++; then
     echo "Running C++ examples";
 
     ((max_test=${#examples[@]}))


### PR DESCRIPTION
Instead of checking for rustc. Seems like a copy & paste mistake.

Regards,
Sebastian 
